### PR TITLE
Add type-hinting to return types

### DIFF
--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -37,14 +37,14 @@ class Breadcrumb
     /**
      * @return \Fragkp\LaravelRouteBreadcrumb\BreadcrumbLink|null
      */
-    public function index()
+    public function index(): ?BreadcrumbLink
     {
         $indexRoute = $this->routes()->first(function (Route $route) {
             return $route->getAction('breadcrumbIndex');
         });
 
         if (! $indexRoute) {
-            return;
+            return null;
         }
 
         return app(BreadcrumbLinkFactory::class)->create($indexRoute->uri(), $indexRoute);
@@ -53,7 +53,7 @@ class Breadcrumb
     /**
      * @return \Illuminate\Support\Collection
      */
-    public function links()
+    public function links(): Collection
     {
         $links = $this->groupLinks();
 
@@ -75,7 +75,7 @@ class Breadcrumb
     /**
      * @return \Illuminate\Support\Collection
      */
-    protected function groupLinks()
+    protected function groupLinks(): Collection
     {
         $pathPrefixes = $this->groupPrefixes(
             $this->request->path()
@@ -102,12 +102,12 @@ class Breadcrumb
     /**
      * @return \Fragkp\LaravelRouteBreadcrumb\BreadcrumbLink|null
      */
-    public function current()
+    public function current(): ?BreadcrumbLink
     {
         $route = $this->request->route();
 
         if (! $route || ! isset($route->getAction()['breadcrumb'])) {
-            return;
+            return null;
         }
 
         return app(BreadcrumbLinkFactory::class)->create($this->request->path(), $route);
@@ -127,7 +127,7 @@ class Breadcrumb
      * @param string $currentPath
      * @return array
      */
-    protected function groupPrefixes(string $currentPath)
+    protected function groupPrefixes(string $currentPath): array
     {
         $prefixes = array_map(function ($prefix) use ($currentPath) {
             return str_before($currentPath, $prefix);

--- a/src/BreadcrumbLinkFactory.php
+++ b/src/BreadcrumbLinkFactory.php
@@ -27,7 +27,7 @@ class BreadcrumbLinkFactory
      * @param \Illuminate\Routing\Route $route
      * @return \Fragkp\LaravelRouteBreadcrumb\BreadcrumbLink|null
      */
-    public function create(string $uri, Route $route)
+    public function create(string $uri, Route $route): ?BreadcrumbLink
     {
         $route = RouteParameterBinder::bind($this->request, $route);
 
@@ -37,7 +37,7 @@ class BreadcrumbLinkFactory
                 static::routeParameters($route)
             );
         } catch (TypeError $error) {
-            return;
+            return null;
         }
 
         return new BreadcrumbLink($uri, $resolvedTitle);
@@ -47,7 +47,7 @@ class BreadcrumbLinkFactory
      * @param \Illuminate\Routing\Route $route
      * @return array
      */
-    protected static function routeParameters(Route $route)
+    protected static function routeParameters(Route $route): array
     {
         return $route->hasParameters()
             ? array_values($route->parameters())
@@ -59,7 +59,7 @@ class BreadcrumbLinkFactory
      * @param array           $parameters
      * @return string
      */
-    protected static function resolveTitle($title, array $parameters)
+    protected static function resolveTitle($title, array $parameters): string
     {
         if ($title instanceof Closure) {
             return $title(...$parameters);

--- a/src/BreadcrumbServiceProvider.php
+++ b/src/BreadcrumbServiceProvider.php
@@ -12,7 +12,7 @@ class BreadcrumbServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->app->singleton(Breadcrumb::class);
     }
@@ -22,7 +22,7 @@ class BreadcrumbServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         if (! Route::hasMacro('breadcrumb')) {
             Route::macro('breadcrumb', function ($title) {

--- a/src/Facades/Breadcrumb.php
+++ b/src/Facades/Breadcrumb.php
@@ -11,7 +11,7 @@ class Breadcrumb extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return \Fragkp\LaravelRouteBreadcrumb\Breadcrumb::class;
     }

--- a/src/RouteParameterBinder.php
+++ b/src/RouteParameterBinder.php
@@ -12,7 +12,7 @@ class RouteParameterBinder
      * @param \Illuminate\Routing\Route $route
      * @return \Illuminate\Routing\Route
      */
-    public static function bind(Request $request, Route $route)
+    public static function bind(Request $request, Route $route): Route
     {
         $compiledRouteParameters = $route->getCompiled()->getVariables();
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -14,7 +14,7 @@ class IntegrationTest extends TestCase
     protected static $controllerAction = 'Fragkp\\LaravelRouteBreadcrumb\\Tests\\TestController@index';
 
     /** @test */
-    public function it_not_changes_the_default_behavior()
+    public function it_not_changes_the_default_behavior(): void
     {
         Route::get('/foo', static::$controllerAction);
 
@@ -31,7 +31,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_is_empty_when_no_route_is_found()
+    public function it_is_empty_when_no_route_is_found(): void
     {
         $this->get('/foo')->assertStatus(404);
 
@@ -46,7 +46,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_is_empty_when_an_error_occurs()
+    public function it_is_empty_when_an_error_occurs(): void
     {
         Route::get('/foo', function () {
             throw new \Exception;
@@ -65,7 +65,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_always_the_breadcrumb_index()
+    public function it_returns_always_the_breadcrumb_index(): void
     {
         Route::get('/', static::$controllerAction)->breadcrumbIndex('Start');
 
@@ -89,7 +89,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_only_the_matched_breadcrumb()
+    public function it_returns_only_the_matched_breadcrumb(): void
     {
         Route::get('/foo', static::$controllerAction)->breadcrumb('Foo');
         Route::get('/bar/camp', static::$controllerAction)->breadcrumb('Bar');
@@ -112,7 +112,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_only_the_matched_and_defined_index_breadcrumbs()
+    public function it_returns_only_the_matched_and_defined_index_breadcrumbs(): void
     {
         Route::get('/', static::$controllerAction)->breadcrumbIndex('Start');
         Route::get('/foo', static::$controllerAction)->breadcrumb('First');
@@ -134,7 +134,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_always_the_first_index()
+    public function it_returns_always_the_first_index(): void
     {
         Route::get('/bar', static::$controllerAction)->breadcrumbIndex('Start first');
         Route::get('/', static::$controllerAction)->breadcrumbIndex('Start second');
@@ -158,7 +158,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_the_breadcrumb_title_by_closure()
+    public function it_can_handle_the_breadcrumb_title_by_closure(): void
     {
         Route::get('/foo', static::$controllerAction)->breadcrumb(function () {
             return 'Closure title';
@@ -178,7 +178,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_the_breadcrumb_title_by_custom_class()
+    public function it_can_handle_the_breadcrumb_title_by_custom_class(): void
     {
         Route::get('/foo', static::$controllerAction)->breadcrumb(CustomTitleResolver::class);
 
@@ -196,7 +196,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_the_breadcrumb_inside_a_group()
+    public function it_returns_the_breadcrumb_inside_a_group(): void
     {
         Route::get('/', static::$controllerAction)->breadcrumbIndex('Start');
 
@@ -221,7 +221,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_the_breadcrumb_inside_a_group_with_the_group_index()
+    public function it_returns_the_breadcrumb_inside_a_group_with_the_group_index(): void
     {
         Route::get('/', static::$controllerAction)->breadcrumbIndex('Start');
 
@@ -248,7 +248,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_multiple_nested_groups()
+    public function it_can_handle_multiple_nested_groups(): void
     {
         Route::get('/', static::$controllerAction)->breadcrumbIndex('Start');
 
@@ -285,7 +285,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_route_model_binding()
+    public function it_can_handle_route_model_binding(): void
     {
         $this->migrate();
 
@@ -309,7 +309,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_route_model_binding_and_resolves_title_by_closure()
+    public function it_can_handle_route_model_binding_and_resolves_title_by_closure(): void
     {
         $this->migrate();
 
@@ -335,7 +335,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_route_model_binding_and_resolves_title_by_custom_class()
+    public function it_can_handle_route_model_binding_and_resolves_title_by_custom_class(): void
     {
         $this->migrate();
 
@@ -359,7 +359,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_multiple_route_model_bindings_inside_groups()
+    public function it_can_handle_multiple_route_model_bindings_inside_groups(): void
     {
         $this->migrate();
 
@@ -399,7 +399,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_custom_route_model_binding()
+    public function it_can_handle_custom_route_model_binding(): void
     {
         Route::bind('customBinding', function ($value) {
             return new CustomBinding($value);
@@ -423,7 +423,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_handle_nested_route_parameters_with_route_model_binding_for_group_index()
+    public function it_can_handle_nested_route_parameters_with_route_model_binding_for_group_index(): void
     {
         Route::bind('customBinding', function ($value) {
             return new CustomBinding($value);
@@ -462,7 +462,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_the_index_when_nested_routes_with_parameters_doesnt_match_route_binding_current()
+    public function it_returns_the_index_when_nested_routes_with_parameters_doesnt_match_route_binding_current(): void
     {
         Route::bind('customBinding', function ($value) {
             return new CustomBinding($value);
@@ -510,7 +510,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_the_index_when_nested_routes_with_parameters_doesnt_match_route_binding_links()
+    public function it_returns_the_index_when_nested_routes_with_parameters_doesnt_match_route_binding_links(): void
     {
         Route::bind('customBinding', function ($value) {
             return new CustomBinding($value);
@@ -560,7 +560,7 @@ class IntegrationTest extends TestCase
 
 class TestController
 {
-    public function index()
+    public function index(): string
     {
         return 'test';
     }
@@ -594,7 +594,7 @@ class SecondBinding
 
 class CustomTitleResolver
 {
-    public function __invoke()
+    public function __invoke(): string
     {
         return 'Class title';
     }
@@ -602,7 +602,7 @@ class CustomTitleResolver
 
 class CustomRouteModelBindingTitleResolver
 {
-    public function __invoke(Foo $foo)
+    public function __invoke(Foo $foo): string
     {
         return "Id: {$foo->id}";
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 abstract class TestCase extends OrchestraTestCase
 {
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             \Fragkp\LaravelRouteBreadcrumb\BreadcrumbServiceProvider::class,
@@ -14,7 +14,7 @@ abstract class TestCase extends OrchestraTestCase
         ];
     }
 
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
@@ -24,7 +24,7 @@ abstract class TestCase extends OrchestraTestCase
         ]);
     }
 
-    protected function migrate()
+    protected function migrate(): void
     {
         $this->loadMigrationsFrom(realpath(__DIR__.'/database/migrations'));
 


### PR DESCRIPTION
I noted that the CI suite only builds against PHP 7.1 and 7.2.  Therefore I assumed this package was aimed at recent versions of PHP only where type-hinting return types are supported.  I went and added the type-hinting as a way to help promote this more recent construct in PHP to help make the code more readable, and maintainable in the future.